### PR TITLE
feat: Prepare crate for publishing on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,13 @@
 [package]
 name = "conv_bit"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
+description = "컴퓨터 구조 학습을 위한 숫자 진법 변환 라이브러리"
+authors = ["your-name <your-email@example.com>"]
+license = "GPL-3.0-or-later"
+repository = "https://github.com/example/conv_bit"
+readme = "README.md"
+keywords = ["진법", "변환", "2진수", "10진수", "8진수", "16진수", "비트"]
+categories = ["command-line-utilities", "computer-science", "encoding"]
 
 [dependencies]


### PR DESCRIPTION
Updates the `Cargo.toml` file with the necessary metadata for publishing to crates.io.

- Sets the Rust edition to 2021.
- Adds description, license, repository, readme, keywords, and categories.
- Uses placeholder values for author and repository URL.